### PR TITLE
Use portalocker for cross-platform locking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 dependencies = [
     "tomli >= 1.2.0 ; python_version < '3.11'",
     "httpx >= 0.25.0",
+    "portalocker>=2.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- switch Context7 service to portalocker
- update dependencies to include portalocker

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405dbcd5c4832e94fe0a411ae277ea