### PR TITLE
Fix pytest asyncio deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
 ]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary
- enable strict asyncio mode and set the fixture loop scope

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405db81e0c832e8d45c8a2ae5d95e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test configuration to enforce strict mode for asyncio tests and set the default event loop fixture scope to function-level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->